### PR TITLE
chore: remove aad auth from webapp module

### DIFF
--- a/infra/core/host/webapp/variables.tf
+++ b/infra/core/host/webapp/variables.tf
@@ -62,15 +62,6 @@ variable "keyVaultName" {
   type = string
 }
 
-variable "aadClientId" {
-  type = string
-  default = ""
-}
-
-variable "tenantId" {
-  type = string
-  default = ""
-}
 
 variable "scmDoBuildDuringDeployment" {
   type = bool

--- a/infra/core/host/webapp/webapp.tf
+++ b/infra/core/host/webapp/webapp.tf
@@ -136,25 +136,6 @@ resource "azurerm_linux_web_app" "app_service" {
     failed_request_tracing = true
   }
 
-  auth_settings_v2 {
-    auth_enabled = true
-    default_provider = "azureactivedirectory"
-    runtime_version = "~2"
-    unauthenticated_action = "RedirectToLoginPage"
-    require_https = true
-    active_directory_v2{
-      client_id = var.aadClientId
-      login_parameters = {}
-      tenant_auth_endpoint = "https://sts.windows.net/${var.tenantId}/v2.0"
-      www_authentication_disabled  = false
-      allowed_audiences = [
-        "api://${var.name}"
-      ]
-    }
-    login{
-      token_store_enabled = false
-    }
-  }
 }
 
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs_commercial" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -353,7 +353,6 @@ module "webapp" {
   applicationInsightsConnectionString = module.logging.applicationInsightsConnectionString
   keyVaultUri                         = module.kvModule.keyVaultUri
   keyVaultName                        = module.kvModule.keyVaultName
-  tenantId                            = data.azurerm_client_config.current.tenant_id
   is_secure_mode                      = var.is_secure_mode
   subnet_name                         = var.is_secure_mode ? module.network[0].snetApp_name : null
   vnet_name                           = var.is_secure_mode ? module.network[0].vnet_name : null
@@ -413,7 +412,6 @@ module "webapp" {
     AZURE_AI_CREDENTIAL_DOMAIN               = var.azure_ai_private_link_domain
   }
 
-  aadClientId = module.entraObjects.azure_ad_web_app_client_id
   depends_on = [ module.kvModule ]
 }
 


### PR DESCRIPTION
## Summary
- remove auth_settings_v2 block and Active Directory configuration from webapp
- drop unused aadClientId/tenantId variables and references
- update main module call to omit aadClientId input

## Testing
- `terraform fmt infra/core/host/webapp/webapp.tf infra/core/host/webapp/variables.tf infra/main.tf` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e4e4ef348322891932945d2c65a6