### PR TITLE
Add basic login/signup pages with auth routing

### DIFF
--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { HashRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route, Navigate } from "react-router-dom";
 import { initializeIcons } from "@fluentui/react";
 
 import "./index.css";
@@ -14,6 +14,23 @@ import Chat from "./pages/chat/Chat";
 import Content from "./pages/content/Content";
 import Tutor from "./pages/tutor/Tutor";
 import { Tda } from "./pages/tda/Tda";
+import Login from "./pages/Login";
+import Signup from "./pages/Signup";
+
+const authDisabled = import.meta.env.VITE_AUTH_DISABLED === "true";
+
+const getStoredUser = () => {
+    const sessionUser = sessionStorage.getItem("user");
+    const localUser = localStorage.getItem("user");
+    return sessionUser || localUser;
+};
+
+const RequireAuth = ({ children }: { children: JSX.Element }) => {
+    if (authDisabled || getStoredUser()) {
+        return children;
+    }
+    return <Navigate to="/login" replace />;
+};
 
 initializeIcons();
 
@@ -22,15 +39,24 @@ export default function App() {
     return (
         <HashRouter>
             <Routes>
-                <Route path="/" element={<Layout />}>
+                <Route path="/login" element={<Login />} />
+                <Route path="/signup" element={<Signup />} />
+                <Route
+                    path="/"
+                    element={
+                        <RequireAuth>
+                            <Layout />
+                        </RequireAuth>
+                    }
+                >
                     <Route index element={<Chat />} />
                     <Route path="content" element={<Content />} />
                     <Route path="*" element={<NoPage />} />
                     <Route path="tutor" element={<Tutor />} />
                     <Route path="tda" element={<Tda folderPath={""} tags={[]} />} />
-            </Route>
+                </Route>
             </Routes>
-        </HashRouter>    
+        </HashRouter>
     );
 }
 

--- a/app/frontend/src/pages/Login.tsx
+++ b/app/frontend/src/pages/Login.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+const Login = () => {
+    const navigate = useNavigate();
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [remember, setRemember] = useState(false);
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const user = { username };
+        if (remember) {
+            localStorage.setItem("user", JSON.stringify(user));
+        } else {
+            sessionStorage.setItem("user", JSON.stringify(user));
+        }
+        navigate("/");
+    };
+
+    return (
+        <div>
+            <h2>Login</h2>
+            <form onSubmit={handleSubmit}>
+                <div>
+                    <label htmlFor="username">Username</label>
+                    <input
+                        id="username"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        required
+                    />
+                </div>
+                <div>
+                    <label htmlFor="password">Password</label>
+                    <input
+                        id="password"
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                    />
+                </div>
+                <div>
+                    <label>
+                        <input
+                            type="checkbox"
+                            checked={remember}
+                            onChange={(e) => setRemember(e.target.checked)}
+                        />
+                        Remember me
+                    </label>
+                </div>
+                <button type="submit">Login</button>
+            </form>
+            <p>
+                Don't have an account? <Link to="/signup">Sign up</Link>
+            </p>
+        </div>
+    );
+};
+
+export default Login;

--- a/app/frontend/src/pages/Signup.tsx
+++ b/app/frontend/src/pages/Signup.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+const Signup = () => {
+    const navigate = useNavigate();
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const user = { username };
+        localStorage.setItem("user", JSON.stringify(user));
+        navigate("/");
+    };
+
+    return (
+        <div>
+            <h2>Sign Up</h2>
+            <form onSubmit={handleSubmit}>
+                <div>
+                    <label htmlFor="username">Username</label>
+                    <input
+                        id="username"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        required
+                    />
+                </div>
+                <div>
+                    <label htmlFor="password">Password</label>
+                    <input
+                        id="password"
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                    />
+                </div>
+                <button type="submit">Create Account</button>
+            </form>
+            <p>
+                Already have an account? <Link to="/login">Log in</Link>
+            </p>
+        </div>
+    );
+};
+
+export default Signup;


### PR DESCRIPTION
## Summary
- add Login and Signup pages with form logic and storage for user state
- require authentication for chat routes with ability to bypass when `VITE_AUTH_DISABLED` is set

## Testing
- `cd app/frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a3e500b8e08322aca09792a944decb