### PR TITLE
Handle missing Azure login and fix infrastructure script condition

### DIFF
--- a/scripts/check-subscription.sh
+++ b/scripts/check-subscription.sh
@@ -24,12 +24,15 @@ then
     az account set -s "$ARM_SUBSCRIPTION_ID"
 fi
 
-export CURRENT_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-echo -e "Using subscription id $CURRENT_SUBSCRIPTION_ID"
+if ! CURRENT_SUBSCRIPTION_ID=$(az account show --query id --output tsv 2>/dev/null); then
+    echo -e "ERROR: Please run 'az login' to setup account."
+    exit 1
+fi
+export CURRENT_SUBSCRIPTION_ID
+echo -e "Using subscription id ${CURRENT_SUBSCRIPTION_ID}"
 
-# If the ARM_SUBSCRIPTION_ID is set, compare it with the 
-if [ -n "$ARM_SUBSCRIPTION_ID" ] && [ $CURRENT_SUBSCRIPTION_ID != "$ARM_SUBSCRIPTION_ID" ]
-then
+# If the ARM_SUBSCRIPTION_ID is set, compare it with the current subscription
+if [ -n "$ARM_SUBSCRIPTION_ID" ] && [ "$CURRENT_SUBSCRIPTION_ID" != "$ARM_SUBSCRIPTION_ID" ]; then
     echo -e "*** INCORRECT SUBSCRIPTION ***."
     echo -e "Either use subscription id $ARM_SUBSCRIPTION_ID, or unset the ARM_SUBSCRIPTION_ID environment variable in your .env"
     exit 1

--- a/scripts/inf-create.sh
+++ b/scripts/inf-create.sh
@@ -25,6 +25,7 @@ then
     if [ -n "${AZURE_ENVIRONMENT}" ] && [[ $AZURE_ENVIRONMENT == "AzureUSGovernment" ]]; then
         az cloud set --name AzureUSGovernment
     fi
+fi
 
 # Check for existing DDOS Protection Plan and use it if available
 if [[ "$SECURE_MODE" == "true" ]]; then


### PR DESCRIPTION
## Summary
- exit early in `check-subscription.sh` when no Azure login is present and compare subscriptions safely
- close automation block in `inf-create.sh` to avoid syntax errors when deploying infrastructure

## Testing
- `bash -n scripts/check-subscription.sh`
- `bash -n scripts/inf-create.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3eeb9d6048322a684e71b5b30a500