### PR TITLE
fix: close webapp resource block

### DIFF
--- a/infra/core/host/webapp/webapp.tf
+++ b/infra/core/host/webapp/webapp.tf
@@ -136,6 +136,8 @@ resource "azurerm_linux_web_app" "app_service" {
     failed_request_tracing = true
   }
 
+}
+
 resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs_commercial" {
   count                      = var.azure_environment == "AzureUSGovernment" ? 0 : 1
   name                       = azurerm_linux_web_app.app_service.name


### PR DESCRIPTION
## Summary
- close azurerm_linux_web_app resource before diagnostic settings

## Testing
- `terraform fmt infra/core/host/webapp/webapp.tf` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*
- `curl -L -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip` *(fails: CONNECT tunnel failed 403)*
- `terraform validate infra/core/host` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f0d230b88322a93df590e666da5b