### PR TITLE
Capture source URLs for JSON ingestion chunks

### DIFF
--- a/tests/unit/test_file_layout_parsing_other.py
+++ b/tests/unit/test_file_layout_parsing_other.py
@@ -58,6 +58,7 @@ def test_partition_file_json_html_content(file_layout_module):
     sample_payload = {
         "Title": "My Document",
         "Content": "<p>Welcome <strong>reader</strong></p>",
+        "source_url": "https://contoso.example/source",
     }
     payload_bytes = json.dumps(sample_payload).encode("utf-8")
 
@@ -74,9 +75,10 @@ def test_partition_file_json_html_content(file_layout_module):
     with patch.object(file_layout_module.requests, "get", return_value=DummyResponse(payload_bytes)), \
             patch("unstructured.partition.html.partition_html", return_value=[html_element]), \
             patch("unstructured.partition.text.partition_text", return_value=[text_element]):
-        elements, metadata = file_layout_module.PartitionFile(".json", "https://example.com/test.json")
+        elements, metadata, source_url = file_layout_module.PartitionFile(".json", "https://example.com/test.json")
 
     element_texts = [getattr(element, "text", "") for element in elements if getattr(element, "text", "")]
 
     assert any("Welcome" in text for text in element_texts)
     assert "Title: My Document" in metadata
+    assert source_url == "https://contoso.example/source"


### PR DESCRIPTION
## Summary
- capture a `source_url` from JSON ingestion payloads and propagate it through chunk creation
- prefer the captured `source_url` over the blob URI when writing chunk metadata
- extend the JSON partition unit test to cover the new source URL handling

## Testing
- pytest tests/unit/test_file_layout_parsing_other.py

------
https://chatgpt.com/codex/tasks/task_e_68cab22485a88322a8eee4592f5681d8